### PR TITLE
Refactor into PseudoTCP struct

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -25,21 +25,24 @@ type DNSResponse struct {
 	} `json:"Answer"`
 }
 
+type dnsCacheEntry struct {
+	result  *dns.Msg
+	created time.Time
+}
+
+type dnsClientState struct {
+	h2Transport *http2.Transport
+	cache       map[string]*dnsCacheEntry // maps from Question to dnsCacheEntry
+	mu          sync.RWMutex
+}
+
 // The default DNS-over-HTTPS server to use for DNS queries.
 var DEFAULT_DOH_SERVER_ADDRS = []string{"1.1.1.1:443", "1.0.0.1:443", "1.1.1.2:443", "1.0.0.2:443"}
 var DEFAULT_POPULAR_DNS_NAMES []string = []string{"api.invisv.com"}
 
-// configuredDoHServers is the list of servers we were configured to use.
-// This list is copied to activeDoHServers when the relay is started.
-// If this is empty, we use the default list.
-var configuredDoHServers []string
-
-// activeDoHServers is the list of servers currently in use.
-var activeDoHServers []string
-
-func ResolveDOHJSON(host string) (string, error) {
+func (t *PseudoTCP) ResolveDOHJSON(host string) (string, error) {
 	var d net.Dialer
-	d.Control = dialerControlProtect(currentProtect)
+	d.Control = t.dialerControlProtect()
 
 	tr := &http2.Transport{
 		DialTLS: func(network, addr string, cfg *tls.Config) (net.Conn, error) {
@@ -52,87 +55,74 @@ func ResolveDOHJSON(host string) (string, error) {
 	reader, writer := io.Pipe()
 	req, err := http.NewRequest("GET", "https://1.1.1.1/dns-query?name="+host, reader)
 	if err != nil {
-		logger.Error("Error creating DNS request", "err", err, "host", host)
+		t.logger.Error("Error creating DNS request", "err", err, "host", host)
 		return "", err
 	}
 	req.Header.Set("Accept", "application/dns-json")
 	response, err := tr.RoundTrip(req)
 	if err != nil {
-		logger.Error("Error sending DNS request", "err", err, "req", req)
+		t.logger.Error("Error sending DNS request", "err", err, "req", req)
 		return "", err
 	}
 
 	defer func() {
 		if err := response.Body.Close(); err != nil {
-			logger.Error("Error closing body", "err", err)
+			t.logger.Error("Error closing body", "err", err)
 		}
 	}()
 
 	err = writer.Close()
 	if err != nil {
-		logger.Error("Error closing writer", "err", err)
+		t.logger.Error("Error closing writer", "err", err)
 	}
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
-		logger.Error("Error reading DNS response", "err", err, "response", response)
+		t.logger.Error("Error reading DNS response", "err", err, "response", response)
 		return "", err
 	}
 
-	logger.Debug("DNS response", "body", string(body))
+	t.logger.Debug("DNS response", "body", string(body))
 	dnsResponse := DNSResponse{}
 	err = json.Unmarshal(body, &dnsResponse)
 	if err != nil {
-		logger.Error("Error unmarshalling DNS response", "err", err, "dnsresponse", dnsResponse)
+		t.logger.Error("Error unmarshalling DNS response", "err", err, "dnsresponse", dnsResponse)
 		return "", err
 	}
-	logger.Debug("DNS response", "dnsResponse", dnsResponse)
+	t.logger.Debug("DNS response", "dnsResponse", dnsResponse)
 	for _, answer := range dnsResponse.Answer {
 		if answer.Type == 1 {
-			logger.Debug("DNS response Type 1", "answer.Data", answer.Data)
+			t.logger.Debug("DNS response Type 1", "answer.Data", answer.Data)
 			return answer.Data, nil
 		}
 	}
 	return "", errors.New("no A record found")
 }
 
-type dnsCacheEntry struct {
-	result  *dns.Msg
-	created time.Time
-}
-
-type dnsClientState struct {
-	h2Transport *http2.Transport
-	cache       map[string]*dnsCacheEntry // maps from Question to dnsCacheEntry
-	mu          sync.RWMutex
-}
-
-var dnsClient *dnsClientState
-
 // initDNSClient initializes the DNS client.
-func initDnsClient() {
-	dnsClient = &dnsClientState{
+func (t *PseudoTCP) initDnsClient() {
+	t.dnsClient = &dnsClientState{
 		h2Transport: &http2.Transport{AllowHTTP: false,
 			DisableCompression: true,
 		},
 		cache: make(map[string]*dnsCacheEntry),
 	}
 
-	if len(configuredDoHServers) > 0 {
-		activeDoHServers = make([]string, len(configuredDoHServers))
-		copy(activeDoHServers, configuredDoHServers)
+	if len(t.configuredDoHServers) > 0 {
+		t.activeDoHServers = make([]string, len(t.configuredDoHServers))
+		copy(t.activeDoHServers, t.configuredDoHServers)
 	} else {
-		activeDoHServers = make([]string, len(DEFAULT_DOH_SERVER_ADDRS))
-		copy(activeDoHServers, DEFAULT_DOH_SERVER_ADDRS)
+		t.activeDoHServers = make([]string, len(DEFAULT_DOH_SERVER_ADDRS))
+		copy(t.activeDoHServers, DEFAULT_DOH_SERVER_ADDRS)
 	}
 
-	go precachePopularDnsDomains()
+	go t.precachePopularDnsDomains()
 }
 
-func precachePopularDnsDomains() {
+func (t *PseudoTCP) precachePopularDnsDomains() {
 	for _, domain := range DEFAULT_POPULAR_DNS_NAMES {
 		if _, err := net.LookupHost(domain); err != nil {
-			logger.Error("Error looking up host", "err", err, "domain", domain)
+			t.logger.Error("Error looking up host", "err", err, "domain", domain)
 		}
 	}
 }
@@ -144,16 +134,16 @@ func precachePopularDnsDomains() {
 // send the UDP packet payload;
 // dns -> client: receive DNS response packet(s) from the HTTPS
 // connection, craft a raw UDP packet and send it back to Android.
-func handleDNS(src uint32, sport uint16, dst uint32, dport uint16, buf []byte) {
+func (t *PseudoTCP) handleDNS(src uint32, sport uint16, dst uint32, dport uint16, buf []byte) {
 	dnsStart := time.Now()
 
 	dnsReq := new(dns.Msg)
 	err := dnsReq.Unpack(buf[DEFAULT_UDP_HDR_SIZE:])
 	if err != nil {
-		logger.Error("Error unpacking DNS request", "err", err, "dnsReq", dnsReq)
+		t.logger.Error("Error unpacking DNS request", "err", err, "dnsReq", dnsReq)
 		return
 	}
-	logger.Debug("received DNS request:", "dnsReq", dnsReq, "DNSNAME", dnsReq.Question[0].Name)
+	t.logger.Debug("received DNS request:", "dnsReq", dnsReq, "DNSNAME", dnsReq.Question[0].Name)
 
 	var dnsResp *dns.Msg
 
@@ -161,29 +151,29 @@ func handleDNS(src uint32, sport uint16, dst uint32, dport uint16, buf []byte) {
 	if !(v6) {
 		// Check if we have a cached result for this query.
 		// TODO: add periodic garbage collection of the cache.
-		dnsClient.mu.RLock()
-		if entry, ok := dnsClient.cache[dnsReq.Question[0].String()]; ok {
+		t.dnsClient.mu.RLock()
+		if entry, ok := t.dnsClient.cache[dnsReq.Question[0].String()]; ok {
 			// TODO: respect the TTL.
 			if time.Since(entry.created) < time.Second*DNS_CACHE_TIMEOUT_SECONDS {
-				logger.Debug("Using cached DNS result", "Question", dnsReq.Question[0].String())
+				t.logger.Debug("Using cached DNS result", "Question", dnsReq.Question[0].String())
 				dnsResp = entry.result.Copy()
 				dnsResp.Id = dnsReq.Id
 			} else {
-				logger.Debug("Cached DNS result expired", "Question", dnsReq.Question[0].String())
+				t.logger.Debug("Cached DNS result expired", "Question", dnsReq.Question[0].String())
 			}
 		}
-		dnsClient.mu.RUnlock()
+		t.dnsClient.mu.RUnlock()
 
 		if dnsResp == nil {
 			dnsHttpReq, err := dnsReq.Pack()
 			if err != nil {
-				logger.Error("Error packing DNS request", "err", err, "dnsResp", dnsResp)
+				t.logger.Error("Error packing DNS request", "err", err, "dnsResp", dnsResp)
 				return
 			}
 
 			u := &url.URL{
 				Scheme: "https",
-				Host:   activeDoHServers[sport%uint16(len(activeDoHServers))], // randomly choose between the servers.
+				Host:   t.activeDoHServers[sport%uint16(len(t.activeDoHServers))], // randomly choose between the servers.
 				Path:   "/dns-query",
 			}
 			if u.Port() == "443" {
@@ -192,62 +182,62 @@ func handleDNS(src uint32, sport uint16, dst uint32, dport uint16, buf []byte) {
 
 			req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewReader(dnsHttpReq))
 			if err != nil {
-				logger.Error("Error creating DNS request", "err", err, "u", u)
+				t.logger.Error("Error creating DNS request", "err", err, "u", u)
 				return
 			}
 			req.Header.Set("Content-Type", "application/dns-message")
 			req.Host = u.Host
 
-			resp, err := dnsClient.h2Transport.RoundTrip(req)
+			resp, err := t.dnsClient.h2Transport.RoundTrip(req)
 			if err != nil {
-				logger.Error("Error sending DNS request", "err", err, "req", req)
+				t.logger.Error("Error sending DNS request", "err", err, "req", req)
 				return
 			}
 			defer func() {
 				if err := resp.Body.Close(); err != nil {
-					logger.Error("Error closing body", "err", err)
+					t.logger.Error("Error closing body", "err", err)
 				}
 			}()
 			if resp.StatusCode != http.StatusOK {
-				logger.Error("Error sending DNS request", "resp.Status", resp.Status, "resp", resp)
+				t.logger.Error("Error sending DNS request", "resp.Status", resp.Status, "resp", resp)
 				return
 			}
 
 			respBytes, err := io.ReadAll(resp.Body)
 			if err != nil {
-				logger.Error("Error reading DNS response", "err", err, "resp", resp)
+				t.logger.Error("Error reading DNS response", "err", err, "resp", resp)
 				return
 			}
 			dnsResp = new(dns.Msg)
 			if err := dnsResp.Unpack(respBytes); err != nil {
-				logger.Error("Error unpacking DNS response", "err", err, "respBytes", respBytes)
+				t.logger.Error("Error unpacking DNS response", "err", err, "respBytes", respBytes)
 				return
 			}
 
 			// Cache the result.
-			dnsClient.mu.Lock()
-			dnsClient.cache[dnsReq.Question[0].String()] = &dnsCacheEntry{
+			t.dnsClient.mu.Lock()
+			t.dnsClient.cache[dnsReq.Question[0].String()] = &dnsCacheEntry{
 				result:  dnsResp,
 				created: dnsStart,
 			}
 
-			dnsClient.mu.Unlock()
+			t.dnsClient.mu.Unlock()
 		}
 
-		logger.Debug("DNS response", "dnsResp", dnsResp)
+		t.logger.Debug("DNS response", "dnsResp", dnsResp)
 	} else {
 		// Ignore AAAA.
 		dnsResp = dnsReq.Copy()
-		logger.Debug("Ignoring DNS AAAA", "dnsResp", dnsResp)
+		t.logger.Debug("Ignoring DNS AAAA", "dnsResp", dnsResp)
 	}
 	dnsData, err := dnsResp.Pack()
 	if err != nil {
-		logger.Error("failed to pack DNS response", "err", err, "dnsResp", dnsResp)
+		t.logger.Error("failed to pack DNS response", "err", err, "dnsResp", dnsResp)
 		return
 	}
 
 	if len(dnsData) > (TUN_MTU - DEFAULT_IP_HDR_SIZE - DEFAULT_UDP_HDR_SIZE) {
-		logger.Error("DNS response too big", "len(dnsData)", len(dnsData), "dnsData", dnsData)
+		t.logger.Error("DNS response too big", "len(dnsData)", len(dnsData), "dnsData", dnsData)
 		return
 	}
 
@@ -262,7 +252,7 @@ func handleDNS(src uint32, sport uint16, dst uint32, dport uint16, buf []byte) {
 	setUDPHdr(p[DEFAULT_IP_HDR_SIZE:], dport, sport, uint16(len(dnsData)+DEFAULT_UDP_HDR_SIZE))
 	setIPandL4Checksum(p[:pktsize], PROTO_UDP)
 
-	if err := pseudoSendToLinux(p[:pktsize]); err != nil {
-		logger.Error("Error in pseudoSendToLinux", "err", err)
+	if err := t.pseudoSendToLinux(p[:pktsize]); err != nil {
+		t.logger.Error("Error in pseudoSendToLinux", "err", err)
 	}
 }

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -1,10 +1,38 @@
 package testutils
 
 import (
+	"io"
 	"path"
 	"path/filepath"
 	"runtime"
+
+	masqueH2 "github.com/invisv-privacy/masque/http2"
 )
+
+type ProxyClient struct {
+	*masqueH2.Client
+	ProxyIP string
+}
+
+func (p *ProxyClient) Close() error {
+	return nil
+}
+
+func (p *ProxyClient) Connect() error {
+	return p.Client.ConnectToProxy()
+}
+
+func (p *ProxyClient) CurrentProxyIP() string {
+	return p.ProxyIP
+}
+
+func (p *ProxyClient) CreateTCPStream(addr string) (io.ReadWriteCloser, error) {
+	return p.Client.CreateTCPStream(addr)
+}
+
+func (p *ProxyClient) CreateUDPStream(addr string) (io.ReadWriteCloser, error) {
+	return p.Client.CreateUDPStream(addr)
+}
 
 func RootDir() string {
 	_, b, _, _ := runtime.Caller(0)

--- a/packet.go
+++ b/packet.go
@@ -1,5 +1,7 @@
 package pseudotcp
 
+import "net"
+
 // IP protocol numbers for L4 headers.
 const (
 	PROTO_ICMP byte = 1
@@ -68,3 +70,309 @@ const (
 	ACK_SIZE                              = DEFAULT_IP_HDR_SIZE + DEFAULT_TCP_HDR_SIZE
 	ICMP_UNREACHABLE_SIZE                 = DEFAULT_IP_HDR_SIZE + DEFAULT_ICMP_UNREACHABLE_HDR_SIZE + (DEFAULT_IP_HDR_SIZE + 8)
 )
+
+// Pre-baked packets that have common fields set and the rest of the headers set to defaults or zero.
+var (
+	preBakedSynAck  [DEFAULT_IP_HDR_SIZE + DEFAULT_TCP_HDR_SIZE + 4]byte // extra 4 bytes for WSopt
+	preBakedAck     [DEFAULT_IP_HDR_SIZE + DEFAULT_TCP_HDR_SIZE]byte
+	preBakedRst     [DEFAULT_IP_HDR_SIZE + DEFAULT_TCP_HDR_SIZE]byte
+	preBakedSegment [DEFAULT_IP_HDR_SIZE + DEFAULT_TCP_HDR_SIZE]byte
+
+	preBakedUDP [DEFAULT_IP_HDR_SIZE + DEFAULT_UDP_HDR_SIZE]byte
+
+	preBakedICMP [DEFAULT_IP_HDR_SIZE + DEFAULT_ICMP_UNREACHABLE_HDR_SIZE]byte
+)
+
+// Computes and sets the checksum for the given IP header.
+// Checksum code borrowed from google/gopacket:
+// [https://github.com/google/gopacket/blob/master/layers/tcpip.go]
+func computeIPChecksum(bytes []byte) uint16 {
+	// Clear checksum bytes
+	bytes[10] = 0
+	bytes[11] = 0
+
+	// Compute checksum
+	var csum uint32
+	for i := 0; i < len(bytes); i += 2 {
+		csum += uint32(bytes[i]) << 8
+		csum += uint32(bytes[i+1])
+	}
+	for {
+		// Break when sum is less or equals to 0xFFFF
+		if csum <= 65535 {
+			break
+		}
+		// Add carry to the sum
+		csum = (csum >> 16) + uint32(uint16(csum))
+	}
+	// Flip all the bits
+	return ^uint16(csum)
+}
+
+// Checksums the given TCP/UDP header.
+// Checksum code borrowed from google/gopacket:
+// [https://github.com/google/gopacket/blob/master/layers/tcpip.go]
+func checksumL4(headerAndPayload []byte, protocol uint32, srcIP net.IP, dstIP net.IP) uint16 {
+	if protocol == uint32(PROTO_TCP) {
+		headerAndPayload[TCP_CHECK] = 0
+		headerAndPayload[TCP_CHECK+1] = 0
+	} else if protocol == uint32(PROTO_UDP) {
+		headerAndPayload[UDP_CHECK] = 0
+		headerAndPayload[UDP_CHECK+1] = 0
+	} else if protocol == uint32(PROTO_ICMP) {
+		headerAndPayload[ICMP_CHECK] = 0
+		headerAndPayload[ICMP_CHECK+1] = 0
+	}
+
+	var csum uint32
+
+	if protocol != uint32(PROTO_ICMP) {
+		csum += (uint32(srcIP[0]) + uint32(srcIP[2])) << 8
+		csum += uint32(srcIP[1]) + uint32(srcIP[3])
+		csum += (uint32(dstIP[0]) + uint32(dstIP[2])) << 8
+		csum += uint32(dstIP[1]) + uint32(dstIP[3])
+
+		totalLen := uint32(len(headerAndPayload))
+
+		csum += protocol
+		csum += totalLen & 0xffff
+		csum += totalLen >> 16
+	}
+
+	return tcpipChecksum(headerAndPayload, csum)
+}
+
+// Calculate the TCP/IP checksum defined in rfc1071. The passed-in csum is any
+// initial checksum data that's already been computed.
+// Checksum code borrowed from google/gopacket:
+// [https://github.com/google/gopacket/blob/master/layers/tcpip.go]
+func tcpipChecksum(data []byte, csum uint32) uint16 {
+	// to handle odd lengths, we loop to length - 1, incrementing by 2, then
+	// handle the last byte specifically by checking against the original
+	// length.
+	length := len(data) - 1
+	for i := 0; i < length; i += 2 {
+		// For our test packet, doing this manually is about 25% faster
+		// (740 ns vs. 1000ns) than doing it by calling binary.BigEndian.Uint16.
+		csum += uint32(data[i]) << 8
+		csum += uint32(data[i+1])
+	}
+	if len(data)%2 == 1 {
+		csum += uint32(data[length]) << 8
+	}
+	for csum > 0xffff {
+		csum = (csum >> 16) + (csum & 0xffff)
+	}
+	return ^uint16(csum)
+}
+
+// setIPandL4Checksum sets the IP and TCP checksums for the given IP packet.
+func setIPandL4Checksum(buf []byte, proto uint8) {
+	// Compute IP checksum.
+	cksum := computeIPChecksum(buf[:DEFAULT_IP_HDR_SIZE])
+	buf[IP_CHECK] = byte(cksum >> 8)
+	buf[IP_CHECK+1] = byte(cksum)
+
+	// Compute TCP checksum.
+	srcIP := buf[IP_SRC : IP_SRC+4]
+	dstIP := buf[IP_DST : IP_DST+4]
+	l4Pkt := buf[DEFAULT_IP_HDR_SIZE:]
+	l4sum := checksumL4(l4Pkt, uint32(proto), srcIP, dstIP)
+
+	if proto == PROTO_TCP {
+		l4Pkt[TCP_CHECK] = byte(l4sum >> 8)
+		l4Pkt[TCP_CHECK+1] = byte(l4sum)
+	} else if proto == PROTO_UDP {
+		l4Pkt[UDP_CHECK] = byte(l4sum >> 8)
+		l4Pkt[UDP_CHECK+1] = byte(l4sum)
+	} else if proto == PROTO_ICMP {
+		l4Pkt[ICMP_CHECK] = byte(l4sum >> 8)
+		l4Pkt[ICMP_CHECK+1] = byte(l4sum)
+	}
+}
+
+// setTCPHdr fills in the TCP header |buf| with the given field values.
+func setTCPHdr(buf []byte, sport, dport uint16, seq uint32, ack uint32) {
+	buf[TCP_SRC_PORT] = byte(sport >> 8)
+	buf[TCP_SRC_PORT+1] = byte(sport & 0xff)
+	buf[TCP_DST_PORT] = byte(dport >> 8)
+	buf[TCP_DST_PORT+1] = byte(dport & 0xff)
+	buf[TCP_SEQ_NUM] = byte(seq >> 24)
+	buf[TCP_SEQ_NUM+1] = byte(seq >> 16)
+	buf[TCP_SEQ_NUM+2] = byte(seq >> 8)
+	buf[TCP_SEQ_NUM+3] = byte(seq)
+	buf[TCP_ACK_NUM] = byte(ack >> 24)
+	buf[TCP_ACK_NUM+1] = byte(ack >> 16)
+	buf[TCP_ACK_NUM+2] = byte(ack >> 8)
+	buf[TCP_ACK_NUM+3] = byte(ack)
+}
+
+// makeIPHdr fills in the given header |buf| with default values.
+func makeIPHdr(buf []byte, proto byte) {
+	buf[IP_VERSION_IHL] = 0x45
+	buf[IP_TTL] = 0x40
+	buf[IP_PROTO] = proto
+	buf[IP_CHECK] = 0x00
+	buf[IP_CHECK+1] = 0x00
+}
+
+// setIPHdr fills in the IP header |buf| with the given field values.
+func setIPHdr(buf []byte, src, dst uint32, len uint16) {
+	buf[IP_LEN] = byte(len >> 8)
+	buf[IP_LEN+1] = byte(len)
+	buf[IP_SRC] = byte(src >> 24)
+	buf[IP_SRC+1] = byte(src >> 16)
+	buf[IP_SRC+2] = byte(src >> 8)
+	buf[IP_SRC+3] = byte(src)
+	buf[IP_DST] = byte(dst >> 24)
+	buf[IP_DST+1] = byte(dst >> 16)
+	buf[IP_DST+2] = byte(dst >> 8)
+	buf[IP_DST+3] = byte(dst)
+}
+
+// setUDPHdr fills in the UDP header |buf| with the given field values.
+func setUDPHdr(buf []byte, sport, dport uint16, len uint16) {
+	buf[UDP_SRC_PORT] = byte(sport >> 8)
+	buf[UDP_SRC_PORT+1] = byte(sport & 0xff)
+	buf[UDP_DST_PORT] = byte(dport >> 8)
+	buf[UDP_DST_PORT+1] = byte(dport & 0xff)
+	buf[UDP_LEN] = byte(len >> 8)
+	buf[UDP_LEN+1] = byte(len)
+}
+
+// setICMPHdr fills in the ICMP header |buf| with the given field values.
+func setICMPHdr(buf []byte, t, code uint8, mtu uint16) {
+	buf[ICMP_TYPE] = t
+	buf[ICMP_CODE] = code
+	buf[ICMP_NEXT_HOP_MTU] = byte(mtu >> 8)
+	buf[ICMP_NEXT_HOP_MTU+1] = byte(mtu & 0xff)
+}
+
+// preBakeSynAck fills in the pre-baked SYN-ACK packet.
+func preBakeSynAck() {
+	buf := preBakedSynAck[:]
+	makeIPHdr(buf, PROTO_TCP)
+	buf = buf[DEFAULT_IP_HDR_SIZE:]
+
+	buf[TCP_DATA_OFF] = 0x60
+	buf[TCP_FLAGS] = FLAG_BIT_SYN | FLAG_BIT_ACK
+	buf[TCP_WINDOW] = 0xFF
+	buf[TCP_WINDOW+1] = 0xFF
+
+	// set window scale option
+	buf[TCP_OPTIONS] = 0x03
+	buf[TCP_OPTIONS+1] = 0x03
+	buf[TCP_OPTIONS+2] = 0x09
+	buf[TCP_OPTIONS+3] = 0x00
+}
+
+// preBakeAck fills in the pre-baked ACK packet.
+func preBakeAck() {
+	buf := preBakedAck[:]
+	makeIPHdr(buf, PROTO_TCP)
+	buf = buf[DEFAULT_IP_HDR_SIZE:]
+
+	buf[TCP_DATA_OFF] = 0x50
+	buf[TCP_FLAGS] = FLAG_BIT_ACK
+	buf[TCP_WINDOW] = 0xFF
+	buf[TCP_WINDOW+1] = 0xFF
+}
+
+// preBakeRst fills in the pre-baked RST packet.
+func preBakeRst() {
+	buf := preBakedRst[:]
+	makeIPHdr(buf, PROTO_TCP)
+	buf = buf[DEFAULT_IP_HDR_SIZE:]
+
+	buf[TCP_DATA_OFF] = 0x50
+	buf[TCP_FLAGS] = FLAG_BIT_RST
+	buf[TCP_WINDOW] = 0xFF
+	buf[TCP_WINDOW+1] = 0xFF
+}
+
+// preBakeSegment fills in the pre-baked segment packet.
+func preBakeSegment() {
+	buf := preBakedSegment[:]
+	makeIPHdr(buf, PROTO_TCP)
+	buf = buf[DEFAULT_IP_HDR_SIZE:]
+
+	buf[TCP_DATA_OFF] = 0x50
+	buf[TCP_FLAGS] = FLAG_BIT_ACK
+	buf[TCP_WINDOW] = 0xFF
+	buf[TCP_WINDOW+1] = 0xFF
+}
+
+// preBakeUDP fills in the pre-baked UDP packet.
+func preBakeUDP() {
+	buf := preBakedUDP[:]
+	makeIPHdr(buf, PROTO_UDP)
+	buf = buf[DEFAULT_IP_HDR_SIZE:]
+	buf[UDP_SRC_PORT] = 0x00
+	buf[UDP_SRC_PORT+1] = 0x00
+	buf[UDP_DST_PORT] = 0x00
+	buf[UDP_DST_PORT+1] = 0x00
+	buf[UDP_LEN] = 0x00
+	buf[UDP_LEN+1] = 0x08
+	buf[UDP_CHECK] = 0x00
+	buf[UDP_CHECK+1] = 0x00
+}
+
+// prebakeICMP fills in the pre-baked ICMP unreachable packet.
+func preBakeICMP() {
+	buf := preBakedICMP[:]
+	makeIPHdr(buf, PROTO_ICMP)
+	buf = buf[DEFAULT_IP_HDR_SIZE:]
+	buf[ICMP_TYPE] = 0x03
+	buf[ICMP_CODE] = 0x03
+	buf[ICMP_CHECK] = 0x00
+	buf[ICMP_CHECK+1] = 0x00
+}
+
+// preBakePackets generates the standard pre-baked packets.
+func preBakePackets() {
+	preBakeSynAck()
+	preBakeAck()
+	preBakeRst()
+	preBakeSegment()
+	preBakeUDP()
+	preBakeICMP()
+}
+
+// replyInitialSyn creates a SYN-ACK reply to an initial SYN and returns the generated SYN-ACK.
+func replyInitialSyn(src, dst uint32, sport, dport uint16, seq, ack uint32) [SYNACK_SIZE]byte {
+	// Send SYN-ACK
+	buf := [SYNACK_SIZE]byte{}
+	copy(buf[:], preBakedSynAck[:])
+
+	setIPHdr(buf[:], dst, src, uint16(SYNACK_SIZE))
+	setTCPHdr(buf[DEFAULT_IP_HDR_SIZE:], dport, sport, seq, ack)
+	setIPandL4Checksum(buf[:], PROTO_TCP)
+
+	return buf
+}
+
+// replyRst generates a RST reply to any termination or error condition, and returns the generated RST.
+func replyRst(src, dst uint32, sport, dport uint16, seq, ack uint32) [RST_SIZE]byte {
+	// Send RST
+	buf := [RST_SIZE]byte{}
+	copy(buf[:], preBakedRst[:])
+
+	setIPHdr(buf[:], dst, src, uint16(RST_SIZE))
+	setTCPHdr(buf[DEFAULT_IP_HDR_SIZE:], dport, sport, seq, ack)
+	setIPandL4Checksum(buf[:], PROTO_TCP)
+
+	return buf
+}
+
+// replyAck generates a ACK reply to a normal data segment, and returns the generated ACK.
+func replyAck(src, dst uint32, sport, dport uint16, seq, ack uint32) [ACK_SIZE]byte {
+	// Send ACK
+	buf := [ACK_SIZE]byte{}
+	copy(buf[:], preBakedAck[:])
+
+	setIPHdr(buf[:], dst, src, uint16(ACK_SIZE))
+	setTCPHdr(buf[DEFAULT_IP_HDR_SIZE:], dport, sport, seq, ack)
+	setIPandL4Checksum(buf[:], PROTO_TCP)
+
+	return buf
+}

--- a/protect.go
+++ b/protect.go
@@ -5,33 +5,24 @@ import (
 	"syscall"
 )
 
-// Protect overrides Android's VpnService.protect()
-// Arguments:
-// fileDescriptor is a system file descriptor to protect from the VPN
-type SocketProtector func(fileDescriptor int) error
-
-var (
-	currentProtect SocketProtector
-)
-
 // Configure sets up a socket protect function to be usable as currentProtect
-func ConfigureProtect(protect SocketProtector) {
-	currentProtect = protect
+func (t *PseudoTCP) ConfigureProtect(protect SocketProtector) {
+	t.currentProtect = protect
 }
 
-func dialerControlProtect(prot SocketProtector) func(network, address string, c syscall.RawConn) error {
+func (t *PseudoTCP) dialerControlProtect() func(network, address string, c syscall.RawConn) error {
 	return func(network, address string, c syscall.RawConn) error {
 		err := c.Control(func(fd uintptr) {
-			if prot != nil {
-				logger.Debug("Protecting FD", "fd", fd)
-				if err := prot(int(fd)); err != nil {
-					logger.Error("Error calling  prot", "err", err, "fd", fd)
+			if t.currentProtect != nil {
+				t.logger.Debug("Protecting FD", "fd", fd)
+				if err := t.currentProtect(int(fd)); err != nil {
+					t.logger.Error("Error calling  prot", "err", err, "fd", fd)
 				}
 				if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, 4194304); err != nil {
-					logger.Error("Error setting SO_RCVBUF", "err", err)
+					t.logger.Error("Error setting SO_RCVBUF", "err", err)
 				}
 				if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_SNDBUF, 4194304); err != nil {
-					logger.Error("Error setting SO_SNDBUF", "err", err)
+					t.logger.Error("Error setting SO_SNDBUF", "err", err)
 				}
 			}
 		})

--- a/pseudotcp.go
+++ b/pseudotcp.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"math"
 	"net"
-	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -17,80 +16,6 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	masqueH2 "github.com/invisv-privacy/masque/http2"
-)
-
-const (
-	// MTU of the TUN interface we're using, has to match Android.
-	TUN_MTU                   = 32000
-	INTERNET_MTU              = 1500
-	DNS_CACHE_TIMEOUT_SECONDS = 300
-	DEFAULT_PROXY_PORT        = "443"
-)
-
-var logger *slog.Logger
-
-type SendPacket func(packet []byte, length int) error
-
-var toLinux SendPacket
-
-func Init(sendPacket SendPacket, verbose bool, proxyFQDN, proxyPort string) error {
-
-	if logger == nil {
-		level := slog.LevelInfo
-		if verbose {
-			level = slog.LevelDebug
-		}
-		logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-			Level: level,
-		}))
-		slog.SetDefault(logger)
-	}
-
-	logger.Debug("Initializing", "proxyFQDN", proxyFQDN)
-
-	toLinux = sendPacket
-	return UserStackInit(proxyFQDN, proxyPort)
-}
-
-func Send(packetData []byte) {
-	UserStackIPProcessPacket(packetData)
-}
-
-// TCPFlow tracks the state of a virtual TCP connection between Android and the MASQUE proxy.
-type TCPFlow struct {
-	src            uint32
-	sport          uint16
-	dst            uint32
-	dport          uint16
-	seq            uint32
-	ack            uint32
-	rwin           int32
-	rwinScale      uint8
-	garbageCollect bool
-	proxyConn      io.ReadWriteCloser
-}
-
-// ProhibitDisallowedIPPorts determines whether we check if packets are heading to an "allowed IP/Port" tuple
-// And if we should prohibit them w/ a host unreachable code
-var ProhibitDisallowedIPPorts = true
-
-// activeTCPFlows stores a mapping from client port to the flow structure for TCP flows.
-var activeTCPFlows [65536]*TCPFlow
-
-// pendingTCPSYNs stores a mapping from client port to the flow structure for TCP flows while we're waiting for the MASQUE server to reply.
-var pendingTCPSYNs = make(map[uint16]*TCPFlow)
-var pendingTCPSYNsMutex sync.Mutex
-
-// establishedTCPFlows channel of TCP flows whose connection establishment has completed.
-var establishedTCPFlows = make(chan *TCPFlow)
-var establishedTCPFlowsCount int32
-
-// wakeupUDPConn is used by established TCP flow goroutines to wake up the datapath to process them.
-var wakeupUDPConn net.Conn
-
-const (
-	WAKEUP_PACKET_IP_PORT  string = "10.10.10.10:1234" // Invalid destination for the wakeup packet.
-	WAKEUP_PACKET_IP_VALUE byte   = 10
 )
 
 // UDPFlow tracks the state of a MASQUE connection to a _destination IP/port_ (different from TCP).
@@ -111,392 +36,227 @@ type UDPFlowKey struct {
 	dport uint16
 }
 
-// relayActive indicates whether we can process packets.
-var relayActive bool
+// TCPFlow tracks the state of a virtual TCP connection between Android and the MASQUE proxy.
+type TCPFlow struct {
+	src            uint32
+	sport          uint16
+	dst            uint32
+	dport          uint16
+	seq            uint32
+	ack            uint32
+	rwin           int32
+	rwinScale      uint8
+	garbageCollect bool
+	proxyConn      io.ReadWriteCloser
+}
 
-// activeUDPFlows stores a mapping from client (src) IP/port and server (dst) IP/port to the flow structure for UDP flows.
-var activeUDPFlows map[UDPFlowKey]*UDPFlow
+// Protect overrides Android's VpnService.protect()
+// Arguments:
+// fileDescriptor is a system file descriptor to protect from the VPN
+type SocketProtector func(fileDescriptor int) error
 
-// deadUDPFlows stores a list of UDP flows that have been closed.
-var deadUDPFlows []*UDPFlow
+type SendPacket func(packet []byte, length int) error
 
-// proxyClient stores the HTTP/2 or HTTP/3 connection to the MASQUE proxy.
-var proxyClient *masqueH2.Client
-
-// currentProxyFQDN stores the DNS name of the current proxy.
-var currentProxyFQDN string
-
-// proxyIP stores the IP of the current proxy.
-var proxyIP string
-
-// proxyPort stores the port that the current proxy is listening on.
-var proxyPort string
-
-// Pre-baked packets that have common fields set and the rest of the headers set to defaults or zero.
-var (
-	preBakedSynAck  [DEFAULT_IP_HDR_SIZE + DEFAULT_TCP_HDR_SIZE + 4]byte // extra 4 bytes for WSopt
-	preBakedAck     [DEFAULT_IP_HDR_SIZE + DEFAULT_TCP_HDR_SIZE]byte
-	preBakedRst     [DEFAULT_IP_HDR_SIZE + DEFAULT_TCP_HDR_SIZE]byte
-	preBakedSegment [DEFAULT_IP_HDR_SIZE + DEFAULT_TCP_HDR_SIZE]byte
-
-	preBakedUDP [DEFAULT_IP_HDR_SIZE + DEFAULT_UDP_HDR_SIZE]byte
-
-	preBakedICMP [DEFAULT_IP_HDR_SIZE + DEFAULT_ICMP_UNREACHABLE_HDR_SIZE]byte
+const (
+	// MTU of the TUN interface we're using, has to match Android.
+	TUN_MTU                   = 32000
+	INTERNET_MTU              = 1500
+	DNS_CACHE_TIMEOUT_SECONDS = 300
+	DEFAULT_PROXY_PORT        = "443"
 )
 
-func clearActiveTCPFlows() {
-	for i := range activeTCPFlows {
-		if activeTCPFlows[i] != nil {
-			activeTCPFlows[i].garbageCollect = true
-			if err := activeTCPFlows[i].proxyConn.Close(); err != nil {
-				logger.Error("Error calling activeTCPFlows[i].proxyConn.Close()", "err", err, "activeTCPFlows[i]", activeTCPFlows[i])
+const (
+	WAKEUP_PACKET_IP_PORT  string = "10.10.10.10:1234" // Invalid destination for the wakeup packet.
+	WAKEUP_PACKET_IP_VALUE byte   = 10
+)
+
+type PseudoTCP struct {
+	// proxyIP stores the IP that the current proxy is listening on.
+	proxyIP string
+
+	// proxyPort stores the port that the current proxy is listening on.
+	proxyPort string
+
+	// proxyClient is the masque client
+	proxyClient *masqueH2.Client
+
+	// currentProxyFQDN stores the DNS name of the current proxy.
+	currentProxyFQDN string
+
+	// active indicates whether we can process packets.
+	active bool
+
+	// activeUDPFlows stores a mapping from client (src) IP/port and server (dst) IP/port to the flow structure for UDP flows.
+	activeUDPFlows map[UDPFlowKey]*UDPFlow
+
+	// deadUDPFlows stores a list of UDP flows that have been closed.
+	deadUDPFlows []*UDPFlow
+
+	// currentProtect is the current function to be called to socket protect for the VPN
+	currentProtect SocketProtector
+
+	dnsClient *dnsClientState
+
+	// toLinux is the function for sending packets to the linux stack
+	toLinux SendPacket
+
+	logger *slog.Logger
+
+	// activeTCPFlows stores a mapping from client port to the flow structure for TCP flows.
+	activeTCPFlows [65536]*TCPFlow
+
+	// pendingTCPSYNs stores a mapping from client port to the flow structure for TCP flows while we're waiting for the proxy server to reply.
+	pendingTCPSYNs      map[uint16]*TCPFlow
+	pendingTCPSYNsMutex sync.Mutex
+
+	// establishedTCPFlows channel of TCP flows whose connection establishment has completed.
+	establishedTCPFlows      chan *TCPFlow
+	establishedTCPFlowsCount int32
+
+	// wakeupUDPConn is used by established TCP flow goroutines to wake up the datapath to process them.
+	wakeupUDPConn net.Conn
+
+	udpPktCounter int
+
+	// prohibitDisallowedIPPorts determines whether we check if packets are heading to an "allowed IP/Port" tuple
+	// And if we should prohibit them w/ a host unreachable code
+	prohibitDisallowedIPPorts bool
+
+	// configuredDoHServers is the list of servers we were configured to use.
+	// This list is copied to activeDoHServers when the relay is started.
+	// If this is empty, we use the default list.
+	configuredDoHServers []string
+
+	// activeDoHServers is the list of servers currently in use.
+	activeDoHServers []string
+}
+
+type PseudoTCPConfig struct {
+	Logger *slog.Logger
+
+	SendPacket SendPacket
+
+	ProhibitDisallowedIPPorts bool
+}
+
+func NewPseudoTCP(config *PseudoTCPConfig) *PseudoTCP {
+	// TODO: Either sane defaults or return an error here
+
+	var l *slog.Logger
+	// TODO: replace with DiscardHandler when accepted
+	// https://github.com/golang/go/issues/62005
+	if config.Logger != nil {
+		l = config.Logger
+	} else {
+		l = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	}
+
+	return &PseudoTCP{
+		logger:                    l.With("config", config),
+		toLinux:                   config.SendPacket,
+		prohibitDisallowedIPPorts: config.ProhibitDisallowedIPPorts,
+
+		pendingTCPSYNs:      make(map[uint16]*TCPFlow),
+		establishedTCPFlows: make(chan *TCPFlow),
+	}
+}
+
+// Init initializes the userspace network stack module. This must be called before any other UserStack function.
+// proxyFQDN is the DNS name of the MASQUE proxy server.
+// proxyPort is the port number that the MASQUE proxy server is listening on.
+func (t *PseudoTCP) Init(proxyFQDN, proxyPort string) error {
+	t.logger.Debug("Initializing", "proxyFQDN", proxyFQDN)
+
+	t.proxyIP = ""
+	if t.toLinux == nil {
+		return errors.New("toLinux is nil")
+	}
+	t.currentProxyFQDN = proxyFQDN
+	t.proxyPort = proxyPort
+
+	t.initActiveFlows()
+	preBakePackets()
+	if err := t.initWakeupUDPConn(); err != nil {
+		t.logger.Error("Error in initWakeupUDPConn", "err", err)
+	}
+
+	err := t.connectToProxy()
+	if err != nil {
+		t.active = false
+		t.logger.Error("failed connecting to proxy", "err", err)
+		return err
+	}
+	t.active = true
+	return nil
+}
+
+func (t *PseudoTCP) Send(packetData []byte) {
+	t.UserStackIPProcessPacket(packetData)
+}
+
+func (t *PseudoTCP) SetLogger(l *slog.Logger) {
+	t.logger = l
+}
+
+func (t *PseudoTCP) clearActiveTCPFlows() {
+	for i := range t.activeTCPFlows {
+		if t.activeTCPFlows[i] != nil {
+			t.activeTCPFlows[i].garbageCollect = true
+			if err := t.activeTCPFlows[i].proxyConn.Close(); err != nil {
+				t.logger.Error("Error calling activeTCPFlows[i].proxyConn.Close()", "err", err, "activeTCPFlows[i]", t.activeTCPFlows[i])
 			}
 		}
-		activeTCPFlows[i] = nil
+		t.activeTCPFlows[i] = nil
 	}
 }
 
-func initActiveFlows() {
-	if activeUDPFlows != nil {
-		terminateActiveFlows()
+func (t *PseudoTCP) initActiveFlows() {
+	if t.activeUDPFlows != nil {
+		t.terminateActiveFlows()
 	}
-	clearActiveTCPFlows()
-	activeUDPFlows = make(map[UDPFlowKey]*UDPFlow)
-	deadUDPFlows = make([]*UDPFlow, 0)
-	if proxyClient != nil {
+	t.clearActiveTCPFlows()
+	t.activeUDPFlows = make(map[UDPFlowKey]*UDPFlow)
+	t.deadUDPFlows = make([]*UDPFlow, 0)
+	if t.proxyClient != nil {
 		// TODO: any Close/cleanup for proxyClient?
-		proxyClient = nil
+		t.proxyClient = nil
 	}
 }
 
-func terminateActiveFlows() {
-	for _, flow := range activeUDPFlows {
+func (t *PseudoTCP) terminateActiveFlows() {
+	for _, flow := range t.activeUDPFlows {
 		flow.garbageCollect = true
 		err := flow.proxyConn.Close()
 		if err != nil {
-			logger.Error("Error calling flow.proxyConn.Close()", "err", err, "flow.proxyConn", flow.proxyConn)
+			t.logger.Error("Error calling flow.proxyConn.Close()", "err", err, "flow.proxyConn", flow.proxyConn)
 		}
 	}
-	clearActiveTCPFlows()
-	activeUDPFlows = nil
-	deadUDPFlows = nil
-}
-
-// Computes and sets the checksum for the given IP header.
-// Checksum code borrowed from google/gopacket:
-// [https://github.com/google/gopacket/blob/master/layers/tcpip.go]
-func computeIPChecksum(bytes []byte) uint16 {
-	// Clear checksum bytes
-	bytes[10] = 0
-	bytes[11] = 0
-
-	// Compute checksum
-	var csum uint32
-	for i := 0; i < len(bytes); i += 2 {
-		csum += uint32(bytes[i]) << 8
-		csum += uint32(bytes[i+1])
-	}
-	for {
-		// Break when sum is less or equals to 0xFFFF
-		if csum <= 65535 {
-			break
-		}
-		// Add carry to the sum
-		csum = (csum >> 16) + uint32(uint16(csum))
-	}
-	// Flip all the bits
-	return ^uint16(csum)
-}
-
-// Checksums the given TCP/UDP header.
-// Checksum code borrowed from google/gopacket:
-// [https://github.com/google/gopacket/blob/master/layers/tcpip.go]
-func checksumL4(headerAndPayload []byte, protocol uint32, srcIP net.IP, dstIP net.IP) uint16 {
-	if protocol == uint32(PROTO_TCP) {
-		headerAndPayload[TCP_CHECK] = 0
-		headerAndPayload[TCP_CHECK+1] = 0
-	} else if protocol == uint32(PROTO_UDP) {
-		headerAndPayload[UDP_CHECK] = 0
-		headerAndPayload[UDP_CHECK+1] = 0
-	} else if protocol == uint32(PROTO_ICMP) {
-		headerAndPayload[ICMP_CHECK] = 0
-		headerAndPayload[ICMP_CHECK+1] = 0
-	}
-
-	var csum uint32
-
-	if protocol != uint32(PROTO_ICMP) {
-		csum += (uint32(srcIP[0]) + uint32(srcIP[2])) << 8
-		csum += uint32(srcIP[1]) + uint32(srcIP[3])
-		csum += (uint32(dstIP[0]) + uint32(dstIP[2])) << 8
-		csum += uint32(dstIP[1]) + uint32(dstIP[3])
-
-		totalLen := uint32(len(headerAndPayload))
-
-		csum += protocol
-		csum += totalLen & 0xffff
-		csum += totalLen >> 16
-	}
-
-	return tcpipChecksum(headerAndPayload, csum)
-}
-
-// Calculate the TCP/IP checksum defined in rfc1071. The passed-in csum is any
-// initial checksum data that's already been computed.
-// Checksum code borrowed from google/gopacket:
-// [https://github.com/google/gopacket/blob/master/layers/tcpip.go]
-func tcpipChecksum(data []byte, csum uint32) uint16 {
-	// to handle odd lengths, we loop to length - 1, incrementing by 2, then
-	// handle the last byte specifically by checking against the original
-	// length.
-	length := len(data) - 1
-	for i := 0; i < length; i += 2 {
-		// For our test packet, doing this manually is about 25% faster
-		// (740 ns vs. 1000ns) than doing it by calling binary.BigEndian.Uint16.
-		csum += uint32(data[i]) << 8
-		csum += uint32(data[i+1])
-	}
-	if len(data)%2 == 1 {
-		csum += uint32(data[length]) << 8
-	}
-	for csum > 0xffff {
-		csum = (csum >> 16) + (csum & 0xffff)
-	}
-	return ^uint16(csum)
-}
-
-// setIPandL4Checksum sets the IP and TCP checksums for the given IP packet.
-func setIPandL4Checksum(buf []byte, proto uint8) {
-	// Compute IP checksum.
-	cksum := computeIPChecksum(buf[:DEFAULT_IP_HDR_SIZE])
-	buf[IP_CHECK] = byte(cksum >> 8)
-	buf[IP_CHECK+1] = byte(cksum)
-
-	// Compute TCP checksum.
-	srcIP := buf[IP_SRC : IP_SRC+4]
-	dstIP := buf[IP_DST : IP_DST+4]
-	l4Pkt := buf[DEFAULT_IP_HDR_SIZE:]
-	l4sum := checksumL4(l4Pkt, uint32(proto), srcIP, dstIP)
-
-	if proto == PROTO_TCP {
-		l4Pkt[TCP_CHECK] = byte(l4sum >> 8)
-		l4Pkt[TCP_CHECK+1] = byte(l4sum)
-	} else if proto == PROTO_UDP {
-		l4Pkt[UDP_CHECK] = byte(l4sum >> 8)
-		l4Pkt[UDP_CHECK+1] = byte(l4sum)
-	} else if proto == PROTO_ICMP {
-		l4Pkt[ICMP_CHECK] = byte(l4sum >> 8)
-		l4Pkt[ICMP_CHECK+1] = byte(l4sum)
-	}
-}
-
-// setTCPHdr fills in the TCP header |buf| with the given field values.
-func setTCPHdr(buf []byte, sport, dport uint16, seq uint32, ack uint32) {
-	buf[TCP_SRC_PORT] = byte(sport >> 8)
-	buf[TCP_SRC_PORT+1] = byte(sport & 0xff)
-	buf[TCP_DST_PORT] = byte(dport >> 8)
-	buf[TCP_DST_PORT+1] = byte(dport & 0xff)
-	buf[TCP_SEQ_NUM] = byte(seq >> 24)
-	buf[TCP_SEQ_NUM+1] = byte(seq >> 16)
-	buf[TCP_SEQ_NUM+2] = byte(seq >> 8)
-	buf[TCP_SEQ_NUM+3] = byte(seq)
-	buf[TCP_ACK_NUM] = byte(ack >> 24)
-	buf[TCP_ACK_NUM+1] = byte(ack >> 16)
-	buf[TCP_ACK_NUM+2] = byte(ack >> 8)
-	buf[TCP_ACK_NUM+3] = byte(ack)
-}
-
-// makeIPHdr fills in the given header |buf| with default values.
-func makeIPHdr(buf []byte, proto byte) {
-	buf[IP_VERSION_IHL] = 0x45
-	buf[IP_TTL] = 0x40
-	buf[IP_PROTO] = proto
-	buf[IP_CHECK] = 0x00
-	buf[IP_CHECK+1] = 0x00
-}
-
-// setIPHdr fills in the IP header |buf| with the given field values.
-func setIPHdr(buf []byte, src, dst uint32, len uint16) {
-	buf[IP_LEN] = byte(len >> 8)
-	buf[IP_LEN+1] = byte(len)
-	buf[IP_SRC] = byte(src >> 24)
-	buf[IP_SRC+1] = byte(src >> 16)
-	buf[IP_SRC+2] = byte(src >> 8)
-	buf[IP_SRC+3] = byte(src)
-	buf[IP_DST] = byte(dst >> 24)
-	buf[IP_DST+1] = byte(dst >> 16)
-	buf[IP_DST+2] = byte(dst >> 8)
-	buf[IP_DST+3] = byte(dst)
-}
-
-// setUDPHdr fills in the UDP header |buf| with the given field values.
-func setUDPHdr(buf []byte, sport, dport uint16, len uint16) {
-	buf[UDP_SRC_PORT] = byte(sport >> 8)
-	buf[UDP_SRC_PORT+1] = byte(sport & 0xff)
-	buf[UDP_DST_PORT] = byte(dport >> 8)
-	buf[UDP_DST_PORT+1] = byte(dport & 0xff)
-	buf[UDP_LEN] = byte(len >> 8)
-	buf[UDP_LEN+1] = byte(len)
-}
-
-// setICMPHdr fills in the ICMP header |buf| with the given field values.
-func setICMPHdr(buf []byte, t, code uint8, mtu uint16) {
-	buf[ICMP_TYPE] = t
-	buf[ICMP_CODE] = code
-	buf[ICMP_NEXT_HOP_MTU] = byte(mtu >> 8)
-	buf[ICMP_NEXT_HOP_MTU+1] = byte(mtu & 0xff)
-}
-
-// preBakeSynAck fills in the pre-baked SYN-ACK packet.
-func preBakeSynAck() {
-	buf := preBakedSynAck[:]
-	makeIPHdr(buf, PROTO_TCP)
-	buf = buf[DEFAULT_IP_HDR_SIZE:]
-
-	buf[TCP_DATA_OFF] = 0x60
-	buf[TCP_FLAGS] = FLAG_BIT_SYN | FLAG_BIT_ACK
-	buf[TCP_WINDOW] = 0xFF
-	buf[TCP_WINDOW+1] = 0xFF
-
-	// set window scale option
-	buf[TCP_OPTIONS] = 0x03
-	buf[TCP_OPTIONS+1] = 0x03
-	buf[TCP_OPTIONS+2] = 0x09
-	buf[TCP_OPTIONS+3] = 0x00
-}
-
-// preBakeAck fills in the pre-baked ACK packet.
-func preBakeAck() {
-	buf := preBakedAck[:]
-	makeIPHdr(buf, PROTO_TCP)
-	buf = buf[DEFAULT_IP_HDR_SIZE:]
-
-	buf[TCP_DATA_OFF] = 0x50
-	buf[TCP_FLAGS] = FLAG_BIT_ACK
-	buf[TCP_WINDOW] = 0xFF
-	buf[TCP_WINDOW+1] = 0xFF
-}
-
-// preBakeRst fills in the pre-baked RST packet.
-func preBakeRst() {
-	buf := preBakedRst[:]
-	makeIPHdr(buf, PROTO_TCP)
-	buf = buf[DEFAULT_IP_HDR_SIZE:]
-
-	buf[TCP_DATA_OFF] = 0x50
-	buf[TCP_FLAGS] = FLAG_BIT_RST
-	buf[TCP_WINDOW] = 0xFF
-	buf[TCP_WINDOW+1] = 0xFF
-}
-
-// preBakeSegment fills in the pre-baked segment packet.
-func preBakeSegment() {
-	buf := preBakedSegment[:]
-	makeIPHdr(buf, PROTO_TCP)
-	buf = buf[DEFAULT_IP_HDR_SIZE:]
-
-	buf[TCP_DATA_OFF] = 0x50
-	buf[TCP_FLAGS] = FLAG_BIT_ACK
-	buf[TCP_WINDOW] = 0xFF
-	buf[TCP_WINDOW+1] = 0xFF
-}
-
-// preBakeUDP fills in the pre-baked UDP packet.
-func preBakeUDP() {
-	buf := preBakedUDP[:]
-	makeIPHdr(buf, PROTO_UDP)
-	buf = buf[DEFAULT_IP_HDR_SIZE:]
-	buf[UDP_SRC_PORT] = 0x00
-	buf[UDP_SRC_PORT+1] = 0x00
-	buf[UDP_DST_PORT] = 0x00
-	buf[UDP_DST_PORT+1] = 0x00
-	buf[UDP_LEN] = 0x00
-	buf[UDP_LEN+1] = 0x08
-	buf[UDP_CHECK] = 0x00
-	buf[UDP_CHECK+1] = 0x00
-}
-
-// prebakeICMP fills in the pre-baked ICMP unreachable packet.
-func preBakeICMP() {
-	buf := preBakedICMP[:]
-	makeIPHdr(buf, PROTO_ICMP)
-	buf = buf[DEFAULT_IP_HDR_SIZE:]
-	buf[ICMP_TYPE] = 0x03
-	buf[ICMP_CODE] = 0x03
-	buf[ICMP_CHECK] = 0x00
-	buf[ICMP_CHECK+1] = 0x00
-}
-
-// preBakePackets generates the standard pre-baked packets.
-func preBakePackets() {
-	preBakeSynAck()
-	preBakeAck()
-	preBakeRst()
-	preBakeSegment()
-	preBakeUDP()
-	preBakeICMP()
-}
-
-// replyInitialSyn creates a SYN-ACK reply to an initial SYN, stores a flow entry, and returns the generated SYN-ACK.
-func replyInitialSyn(src, dst uint32, sport, dport uint16, seq, ack uint32) [SYNACK_SIZE]byte {
-	// Send SYN-ACK
-	buf := [SYNACK_SIZE]byte{}
-	copy(buf[:], preBakedSynAck[:])
-
-	setIPHdr(buf[:], dst, src, uint16(SYNACK_SIZE))
-	setTCPHdr(buf[DEFAULT_IP_HDR_SIZE:], dport, sport, seq, ack)
-	setIPandL4Checksum(buf[:], PROTO_TCP)
-
-	return buf
-}
-
-// replyRst generates a RST reply to any termination or error condition, and returns the generated RST.
-func replyRst(src, dst uint32, sport, dport uint16, seq, ack uint32) [RST_SIZE]byte {
-	// Send RST
-	buf := [RST_SIZE]byte{}
-	copy(buf[:], preBakedRst[:])
-
-	setIPHdr(buf[:], dst, src, uint16(RST_SIZE))
-	setTCPHdr(buf[DEFAULT_IP_HDR_SIZE:], dport, sport, seq, ack)
-	setIPandL4Checksum(buf[:], PROTO_TCP)
-
-	return buf
-}
-
-// replyAck generates a ACK reply to a normal data segment, and returns the generated ACK.
-func replyAck(src, dst uint32, sport, dport uint16, seq, ack uint32) [ACK_SIZE]byte {
-	// Send ACK
-	buf := [ACK_SIZE]byte{}
-	copy(buf[:], preBakedAck[:])
-
-	setIPHdr(buf[:], dst, src, uint16(ACK_SIZE))
-	setTCPHdr(buf[DEFAULT_IP_HDR_SIZE:], dport, sport, seq, ack)
-	setIPandL4Checksum(buf[:], PROTO_TCP)
-
-	return buf
+	t.clearActiveTCPFlows()
+	t.activeUDPFlows = nil
+	t.deadUDPFlows = nil
 }
 
 // setupMasque initiates a MASQUE connection via an already-connected proxy to flow.dst:flow.dport.
 // It also starts a goroutine to handle the MASQUE connection, by reading data from it and injecting that data as TCP segments.
-func setupMasque(dstIP net.IP, flow *TCPFlow) {
+func (t *PseudoTCP) setupMasque(dstIP net.IP, flow *TCPFlow) {
 	host := fmt.Sprintf("%v:%v", dstIP, flow.dport)
 
-	logger.Info("Connecting TCP", "host", host)
-	if c, err := proxyClient.CreateTCPStream(host); err != nil {
+	t.logger.Info("Connecting TCP", "host", host)
+	if c, err := t.proxyClient.CreateTCPStream(host); err != nil {
 		// TODO: add more robust error handling, since it's possible we're offline.
 		// TODO: possibly attempt to reconnect to the proxy, and if that fails, make sure to signal that the VPN is down.
-		logger.Error("Error setting up masque for flow", "err", err, "host", host)
-		pendingTCPSYNsMutex.Lock()
-		delete(pendingTCPSYNs, flow.sport)
-		pendingTCPSYNsMutex.Unlock()
+		t.logger.Error("Error setting up masque for flow", "err", err, "host", host)
+		t.pendingTCPSYNsMutex.Lock()
+		delete(t.pendingTCPSYNs, flow.sport)
+		t.pendingTCPSYNsMutex.Unlock()
 		return
 	} else {
-		logger.Info("Connected", "host", host)
+		t.logger.Info("Connected", "host", host)
 		flow.proxyConn = c
 	}
 
 	go func() {
-		establishedTCPFlows <- flow // blocks because establishedTCPFlows is an unbuffered channel
+		t.establishedTCPFlows <- flow // blocks because establishedTCPFlows is an unbuffered channel
 
 		// This Lock()/Unlock() prevents us from starting the goroutine until the SYNACK is sent, because the outbound thread will have the lock.
 		// The unbuffered channel functions as one lock (really a semaphore), because this function can't proceed until the select in the outbound thread.
@@ -504,10 +264,10 @@ func setupMasque(dstIP net.IP, flow *TCPFlow) {
 		// so this (and any other worker goroutine) can't actually start until the outbound thread has finished its work of marking all pending flows as active.
 		//
 		// TODO: consider changing establishedTCPFlows to take {flow,signalingChannel} to signal that the outbound thread has finished its work, and then this goroutine can start.
-		pendingTCPSYNsMutex.Lock()
+		t.pendingTCPSYNsMutex.Lock()
 		//nolint:staticcheck
-		pendingTCPSYNsMutex.Unlock()
-		logger.Debug("setupMasque goroutine started for flow", "flow", flow)
+		t.pendingTCPSYNsMutex.Unlock()
+		t.logger.Debug("setupMasque goroutine started for flow", "flow", flow)
 
 		var b [TUN_MTU]byte
 		var buf []byte = b[:]
@@ -534,12 +294,12 @@ func setupMasque(dstIP net.IP, flow *TCPFlow) {
 				setTCPHdr(buf[DEFAULT_IP_HDR_SIZE:], flow.dport, flow.sport, flow.seq, ack)
 				setIPandL4Checksum(buf[:totalHdrLen], PROTO_TCP)
 
-				err := pseudoSendToLinux(buf[:totalHdrLen])
+				err := t.pseudoSendToLinux(buf[:totalHdrLen])
 				if err != nil {
-					logger.Error("Error sending dummy segment to Linux", "err", err)
+					t.logger.Error("Error sending dummy segment to Linux", "err", err)
 				}
 
-				logger.Debug("flow rwin limited too much, sleeping")
+				t.logger.Debug("flow rwin limited too much, sleeping")
 				time.Sleep(100 * time.Millisecond)
 
 				dummyPacketToggle = false
@@ -551,7 +311,7 @@ func setupMasque(dstIP net.IP, flow *TCPFlow) {
 			if rwin < (3 * TUN_MTU) {
 				runtime.Gosched() // yield to allow the inbound thread to process an ACK
 				targetReadLen = SAFE_PACKET_SIZE
-				logger.Debug("adjusting targetReadLen, based on rwin", "targetReadLen", targetReadLen, "rwin", rwin)
+				t.logger.Debug("adjusting targetReadLen, based on rwin", "targetReadLen", targetReadLen, "rwin", rwin)
 			}
 
 			n, err := flow.proxyConn.Read(buf[totalHdrLen:targetReadLen])
@@ -568,13 +328,13 @@ func setupMasque(dstIP net.IP, flow *TCPFlow) {
 				setIPandL4Checksum(buf[:pktsize], PROTO_TCP)
 
 				atomic.AddUint32(&flow.seq, uint32(n))
-				err = pseudoSendToLinux(buf[:pktsize])
+				err = t.pseudoSendToLinux(buf[:pktsize])
 
 				if err == nil && pktsize > (TUN_MTU>>1) {
-					logger.Debug("Successful send above half MTU", "pktsize", pktsize)
+					t.logger.Debug("Successful send above half MTU", "pktsize", pktsize)
 				}
 				if err != nil && strings.Contains(err.Error(), "ENOBUFS") {
-					logger.Warn("Got ENOBUFS, splitting packet")
+					t.logger.Warn("Got ENOBUFS, splitting packet")
 
 					// If the packet was too large for the TUN, chop it in half and try again.
 					n2 := n >> 1 // amount of payload to put in second TCP segment
@@ -593,33 +353,33 @@ func setupMasque(dstIP net.IP, flow *TCPFlow) {
 					setTCPHdr(buf[DEFAULT_IP_HDR_SIZE:], flow.dport, flow.sport, flow.seq, ack)
 					setIPandL4Checksum(buf[:pktsize1], PROTO_TCP)
 
-					logger.Debug("Sending split packet")
-					err = pseudoSendToLinux(buf[:pktsize1])
+					t.logger.Debug("Sending split packet")
+					err = t.pseudoSendToLinux(buf[:pktsize1])
 					if err == nil {
-						err = pseudoSendToLinux(buf2[:pktsize2])
+						err = t.pseudoSendToLinux(buf2[:pktsize2])
 						if err == nil {
 							// shrink buf and buf2 to half their current size
 							buf = buf[:len(buf)>>1]
 							buf2 = buf2[:len(buf2)>>1]
-							logger.Debug("Shrank buf and buf2", "len(buf)", len(buf), "len(buf2)", len(buf2))
+							t.logger.Debug("Shrank buf and buf2", "len(buf)", len(buf), "len(buf2)", len(buf2))
 						}
 					}
 					if err != nil {
-						logger.Error("Failed to send split packet", "err", err)
+						t.logger.Error("Failed to send split packet", "err", err)
 					}
 				} else if err != nil {
-					logger.Error("Failure sending packet", "err", err)
+					t.logger.Error("Failure sending packet", "err", err)
 				}
 
 				atomic.AddInt32(&flow.rwin, int32(-n))
 			}
 
 			if err != nil {
-				logger.Error("Error reading from port", "flow.sport", flow.sport, "err", err, "flow", flow)
+				t.logger.Error("Error reading from port", "flow.sport", flow.sport, "err", err, "flow", flow)
 				flow.garbageCollect = true
 				err := flow.proxyConn.Close()
 				if err != nil {
-					logger.Error("Error in flow.proxyConn.Close()", "err", err, "flow.proxyConn", flow.proxyConn)
+					t.logger.Error("Error in flow.proxyConn.Close()", "err", err, "flow.proxyConn", flow.proxyConn)
 				}
 			}
 		}
@@ -627,21 +387,21 @@ func setupMasque(dstIP net.IP, flow *TCPFlow) {
 		// TODO: Close / cleanup the masque connection.
 	}()
 
-	atomic.AddInt32(&establishedTCPFlowsCount, 1)
-	logger.Debug("setupMasque about to send wakeup")
-	_, err := wakeupUDPConn.Write([]byte{0x00})
+	atomic.AddInt32(&t.establishedTCPFlowsCount, 1)
+	t.logger.Debug("setupMasque about to send wakeup")
+	_, err := t.wakeupUDPConn.Write([]byte{0x00})
 	if err != nil {
-		logger.Error("Error writing to wakeup UDP socket", "err", err)
+		t.logger.Error("Error writing to wakeup UDP socket", "err", err)
 	}
 }
 
 // setupUDPMasque initiates a UDP MASQUE connection via an already-connected proxy to flow.dst:flow.dport.
 // It also starts a goroutine to handle the UDP MASQUE connection, sending datagrams to Linux.
-func setupUDPMasque(dstIP net.IP, flow *UDPFlow) error {
+func (t *PseudoTCP) setupUDPMasque(dstIP net.IP, flow *UDPFlow) error {
 	host := fmt.Sprintf("%v:%v", dstIP, flow.dport)
 
-	logger.Debug("Connecting UDP", "host", host)
-	if c, err := proxyClient.CreateUDPStream(host); err != nil {
+	t.logger.Debug("Connecting UDP", "host", host)
+	if c, err := t.proxyClient.CreateUDPStream(host); err != nil {
 		return err
 	} else {
 		flow.proxyConn = c
@@ -663,17 +423,17 @@ func setupUDPMasque(dstIP net.IP, flow *UDPFlow) error {
 				setUDPHdr(buf[DEFAULT_IP_HDR_SIZE:], flow.dport, flow.sport, uint16(n+DEFAULT_UDP_HDR_SIZE))
 				setIPandL4Checksum(buf[:pktsize], PROTO_UDP)
 
-				err := pseudoSendToLinux(buf[:pktsize])
+				err := t.pseudoSendToLinux(buf[:pktsize])
 				if err != nil {
-					logger.Error("Error in pseudoSendToLinux", "err", err, "flow", flow)
+					t.logger.Error("Error in pseudoSendToLinux", "err", err, "flow", flow)
 				}
 			}
 
 			if err != nil {
-				logger.Error("Error reading from port", "flow.sport", flow.sport, "err", err, "flow", flow)
+				t.logger.Error("Error reading from port", "flow.sport", flow.sport, "err", err, "flow", flow)
 				flow.garbageCollect = true
 				// append this flow to deadUDPFlows
-				deadUDPFlows = append(deadUDPFlows, flow)
+				t.deadUDPFlows = append(t.deadUDPFlows, flow)
 			}
 		}
 
@@ -684,153 +444,124 @@ func setupUDPMasque(dstIP net.IP, flow *UDPFlow) error {
 
 // CurrentProxyIP returns the IP of the Proxy A server we are connected to.
 // If relay is not active, returns empty string.
-func CurrentProxyIP() string {
-	if relayActive {
-		return proxyIP
+func (t *PseudoTCP) CurrentProxyIP() string {
+	if t.active {
+		return t.proxyIP
 	}
 	return ""
 }
 
 // connectToProxy connects to the MASQUE proxy and initializes the default MASQUE client.
-func connectToProxy() error {
-	if currentProtect == nil {
+func (t *PseudoTCP) connectToProxy() error {
+	if t.currentProtect == nil {
 		return errors.New("currentProtect is nil")
 	}
 
-	proxy := currentProxyFQDN
+	proxy := t.currentProxyFQDN
 
 	ip := net.ParseIP(proxy)
 	if ip != nil && ip.To4() != nil {
 		// We have an ipv4 address, we can just use that
-		proxyIP = ip.String()
+		t.proxyIP = ip.String()
 	} else if ip != nil && ip.To4() == nil {
 		// We've been given an ipv6 address, we can return an error
 		return fmt.Errorf("ipv6 proxy addresses are unsupported, proxyIP: %v", ip)
 	} else if ip == nil {
 		// Not an ip address, we need to look it up
-		resolvedProxyIP, err := ResolveDOHJSON(proxy)
+		resolvedProxyIP, err := t.ResolveDOHJSON(proxy)
 		if err != nil {
 			return fmt.Errorf("failed to lookup proxy hostname: %w", err)
 		} else {
-			proxyIP = resolvedProxyIP
+			t.proxyIP = resolvedProxyIP
 		}
 	}
 	var proxyAddr string
-	if proxyPort != "" {
-		proxyAddr = proxyIP + ":" + proxyPort
+	if t.proxyPort != "" {
+		proxyAddr = t.proxyIP + ":" + t.proxyPort
 	} else {
-		proxyAddr = proxyIP + ":" + DEFAULT_PROXY_PORT
+		proxyAddr = t.proxyIP + ":" + DEFAULT_PROXY_PORT
 	}
 
-	logger.Debug("resolved proxy", "proxyAddr", proxyAddr)
+	t.logger.Debug("resolved proxy", "proxyAddr", proxyAddr)
 
 	config := masqueH2.ClientConfig{
 		ProxyAddr:  proxyAddr,
 		IgnoreCert: true,
-		Logger:     logger,
+		Logger:     t.logger,
 		AuthToken:  "fake-token",
-		Prot:       masqueH2.SocketProtector(currentProtect),
+		Prot:       masqueH2.SocketProtector(t.currentProtect),
 	}
 
-	proxyClient = masqueH2.NewClient(config)
+	t.proxyClient = masqueH2.NewClient(config)
 
-	err := proxyClient.ConnectToProxy()
+	err := t.proxyClient.ConnectToProxy()
 	if err != nil {
 		return fmt.Errorf("failed to ConnectToProxy: %w", err)
 	}
 
-	initDnsClient()
+	t.initDnsClient()
 
 	return nil
 }
 
-func initWakeupUDPConn() error {
+func (t *PseudoTCP) initWakeupUDPConn() error {
 	// TODO: clean up wakeupUDPConn from before.
 
 	var err error
-	wakeupUDPConn, err = net.Dial("udp4", WAKEUP_PACKET_IP_PORT)
+	t.wakeupUDPConn, err = net.Dial("udp4", WAKEUP_PACKET_IP_PORT)
 	if err != nil {
 		return err
 	}
-	return nil
-}
-
-// UserStackInit initializes the userspace network stack module. This must be called before any other UserStack function.
-// proxyFQDN is the DNS name of the MASQUE proxy server.
-// proxyPort is the port number that the MASQUE proxy server is listening on.
-func UserStackInit(proxyFQDN, port string) error {
-	logger.Info("Starting Relay")
-
-	proxyIP = ""
-	if toLinux == nil {
-		return errors.New("toLinux is nil")
-	}
-	currentProxyFQDN = proxyFQDN
-	proxyPort = port
-
-	initActiveFlows()
-	preBakePackets()
-	if err := initWakeupUDPConn(); err != nil {
-		logger.Error("Error in initWakeupUDPConn", "err", err)
-	}
-
-	err := connectToProxy()
-	if err != nil {
-		relayActive = false
-		logger.Error("failed connecting to proxy", "err", err)
-		return err
-	}
-	relayActive = true
 	return nil
 }
 
 // ReconnectToProxy indicates to the Relay code that it should try to connect to the proxy again.
 // This is good to call when Android detects that a network interface has come back up.
-func ReconnectToProxy(proxyFQDN, port string) error {
-	proxyIP = ""
-	proxyPort = port
+func (t *PseudoTCP) ReconnectToProxy(proxyFQDN, port string) error {
+	t.proxyIP = ""
+	t.proxyPort = port
 
-	currentProxyFQDN = proxyFQDN
+	t.currentProxyFQDN = proxyFQDN
 
-	relayActive = false
-	initActiveFlows()
-	err := connectToProxy()
+	t.active = false
+	t.initActiveFlows()
+	err := t.connectToProxy()
 	if err != nil {
-		relayActive = false
+		t.active = false
 		return err
 	}
-	relayActive = true
+	t.active = true
 	return nil
 }
 
-func Shutdown() {
-	relayActive = false
-	terminateActiveFlows()
-	if proxyClient != nil {
+func (t *PseudoTCP) Shutdown() {
+	t.active = false
+	t.terminateActiveFlows()
+	if t.proxyClient != nil {
 		// TODO: any Close/cleanup for proxyClient?
-		proxyClient = nil
+		t.proxyClient = nil
 	}
-	proxyIP = ""
+	t.proxyIP = ""
 }
 
-func processPendingTCPSYNs() {
-	waitingFlows := atomic.LoadInt32(&establishedTCPFlowsCount)
+func (t *PseudoTCP) processPendingTCPSYNs() {
+	waitingFlows := atomic.LoadInt32(&t.establishedTCPFlowsCount)
 	if waitingFlows > 0 {
-		pendingTCPSYNsMutex.Lock()
-		defer pendingTCPSYNsMutex.Unlock()
+		t.pendingTCPSYNsMutex.Lock()
+		defer t.pendingTCPSYNsMutex.Unlock()
 		for {
 			select {
-			case flow := <-establishedTCPFlows:
-				delete(pendingTCPSYNs, flow.sport)
+			case flow := <-t.establishedTCPFlows:
+				delete(t.pendingTCPSYNs, flow.sport)
 				buf := replyInitialSyn(flow.src, flow.dst, flow.sport, flow.dport, flow.seq, flow.ack)
 				flow.seq += 1
-				activeTCPFlows[flow.sport] = flow
+				t.activeTCPFlows[flow.sport] = flow
 
-				if err := pseudoSendToLinux(buf[:]); err != nil {
-					logger.Error("Error in pseudoSendToLinux", "err", err)
+				if err := t.pseudoSendToLinux(buf[:]); err != nil {
+					t.logger.Error("Error in pseudoSendToLinux", "err", err)
 				}
 
-				atomic.AddInt32(&establishedTCPFlowsCount, -1)
+				atomic.AddInt32(&t.establishedTCPFlowsCount, -1)
 			default:
 				return
 			}
@@ -839,12 +570,12 @@ func processPendingTCPSYNs() {
 }
 
 // processTCPPacket processes a TCP packet |p| from |src|->|dst|, and emits the generated reply to Linux and/or MASQUE.
-func processTCPPacket(src uint32, sport uint16, dst uint32, dstIP net.IP, dport uint16, p []byte) {
+func (t *PseudoTCP) processTCPPacket(src uint32, sport uint16, dst uint32, dstIP net.IP, dport uint16, p []byte) {
 	seq := uint64(uint32(p[TCP_SEQ_NUM])<<24 | uint32(p[TCP_SEQ_NUM+1])<<16 | uint32(p[TCP_SEQ_NUM+2])<<8 | uint32(p[TCP_SEQ_NUM+3]))
 	ack := uint64(uint32(p[TCP_ACK_NUM])<<24 | uint32(p[TCP_ACK_NUM+1])<<16 | uint32(p[TCP_ACK_NUM+2])<<8 | uint32(p[TCP_ACK_NUM+3]))
 	rwin := uint16(p[TCP_WINDOW])<<8 | uint16(p[TCP_WINDOW+1])
 
-	flow := activeTCPFlows[sport]
+	flow := t.activeTCPFlows[sport]
 
 	// Handle initial SYN.
 	if (p[TCP_FLAGS] & FLAG_BIT_SYN) == FLAG_BIT_SYN {
@@ -852,10 +583,10 @@ func processTCPPacket(src uint32, sport uint16, dst uint32, dstIP net.IP, dport 
 			// SYN-ACK already received, ignore.
 			return
 		}
-		pendingTCPSYNsMutex.Lock()
-		if _, ok := pendingTCPSYNs[sport]; ok {
+		t.pendingTCPSYNsMutex.Lock()
+		if _, ok := t.pendingTCPSYNs[sport]; ok {
 			// SYN-ACK already received, ignore.
-			pendingTCPSYNsMutex.Unlock()
+			t.pendingTCPSYNsMutex.Unlock()
 			return
 		}
 
@@ -882,12 +613,12 @@ func processTCPPacket(src uint32, sport uint16, dst uint32, dstIP net.IP, dport 
 		}
 
 		flow := &TCPFlow{src: src, sport: sport, dst: dst, dport: dport, seq: 0, ack: uint32(seq + 1), rwin: int32(rwin), rwinScale: windowScale}
-		pendingTCPSYNs[sport] = flow
-		pendingTCPSYNsMutex.Unlock()
+		t.pendingTCPSYNs[sport] = flow
+		t.pendingTCPSYNsMutex.Unlock()
 
 		dstIPCopy := [4]byte{}
 		copy(dstIPCopy[:], dstIP[:])
-		go setupMasque(dstIPCopy[:], flow)
+		go t.setupMasque(dstIPCopy[:], flow)
 
 		return
 	}
@@ -906,18 +637,18 @@ func processTCPPacket(src uint32, sport uint16, dst uint32, dstIP net.IP, dport 
 
 		buf := replyRst(src, dst, sport, dport, replyseq, replyack)
 
-		if err := pseudoSendToLinux(buf[:]); err != nil {
-			logger.Error("Error in pseudoSendToLinux", "err", err)
+		if err := t.pseudoSendToLinux(buf[:]); err != nil {
+			t.logger.Error("Error in pseudoSendToLinux", "err", err)
 		}
 
 		// Remove any existing flow entry.
 		if flow != nil {
 			if err := flow.proxyConn.Close(); err != nil {
-				logger.Error("Error closing flow.proxyConn", "err", err)
+				t.logger.Error("Error closing flow.proxyConn", "err", err)
 			}
 			// If we're the ones initiating the close, this will signal to the masque -> linux goroutine to stop on its next iteration.
 			flow.garbageCollect = true
-			activeTCPFlows[sport] = nil
+			t.activeTCPFlows[sport] = nil
 		}
 		return
 	}
@@ -935,11 +666,11 @@ func processTCPPacket(src uint32, sport uint16, dst uint32, dstIP net.IP, dport 
 	if fseq < uint32(ack) {
 		if (uint32(ack) - fseq) > (math.MaxUint32 >> 1) {
 			diffAckSeq = uint32(uint64(fseq) + math.MaxUint32 - ack)
-			logger.Debug("handling wrap around of diffAckSeq", "fseq", fseq, "ack", ack, "diffAckSeq", diffAckSeq)
+			t.logger.Debug("handling wrap around of diffAckSeq", "fseq", fseq, "ack", ack, "diffAckSeq", diffAckSeq)
 		} else {
 			// It's possible we see an ack before we've updated the local fseq because these are processed in parallel.
 			// In that case, we should conservatively treat it as if the rwin is current.
-			logger.Debug("handling ack ahead of fseq for diffAckSeq, setting to zero", "fseq", fseq, "ack", ack)
+			t.logger.Debug("handling ack ahead of fseq for diffAckSeq, setting to zero", "fseq", fseq, "ack", ack)
 			diffAckSeq = 0
 		}
 	} else {
@@ -947,10 +678,10 @@ func processTCPPacket(src uint32, sport uint16, dst uint32, dstIP net.IP, dport 
 	}
 
 	if diffAckSeq > 0 {
-		logger.Debug("nonzero difference between seq and ack", "diffAckSeq", diffAckSeq, "availableWindow", availableWindow)
+		t.logger.Debug("nonzero difference between seq and ack", "diffAckSeq", diffAckSeq, "availableWindow", availableWindow)
 		availableWindow -= int32(diffAckSeq)
 		if availableWindow < 0 {
-			logger.Warn("may have negative availableWindow, setting to zero", "availableWindow", availableWindow)
+			t.logger.Warn("may have negative availableWindow, setting to zero", "availableWindow", availableWindow)
 			availableWindow = 0
 		}
 	}
@@ -962,7 +693,7 @@ func processTCPPacket(src uint32, sport uint16, dst uint32, dstIP net.IP, dport 
 		n, err := flow.proxyConn.Write(p[dataoffset:])
 		if err != nil {
 			if err != io.ErrShortWrite {
-				logger.Error("Error writing received bytes to writer", "err", err)
+				t.logger.Error("Error writing received bytes to writer", "err", err)
 
 				// TODO: close/clean up any masque state held by this flow entry.
 
@@ -970,11 +701,11 @@ func processTCPPacket(src uint32, sport uint16, dst uint32, dstIP net.IP, dport 
 				// TODO: verify that this is the right sequence numbering expected by the other side for such a reset.
 				buf := replyRst(src, dst, sport, dport, fseq, fack)
 
-				if err := pseudoSendToLinux(buf[:]); err != nil {
-					logger.Error("Error in pseudoSendToLinux", "err", err)
+				if err := t.pseudoSendToLinux(buf[:]); err != nil {
+					t.logger.Error("Error in pseudoSendToLinux", "err", err)
 				}
 
-				activeTCPFlows[sport] = nil
+				t.activeTCPFlows[sport] = nil
 				flow.garbageCollect = true
 
 				return
@@ -989,78 +720,76 @@ func processTCPPacket(src uint32, sport uint16, dst uint32, dstIP net.IP, dport 
 
 		buf := replyAck(src, dst, sport, dport, fseq, fack)
 
-		if err := pseudoSendToLinux(buf[:]); err != nil {
-			logger.Error("Error in pseudoSendToLinux", "err", err)
+		if err := t.pseudoSendToLinux(buf[:]); err != nil {
+			t.logger.Error("Error in pseudoSendToLinux", "err", err)
 		}
 
 	} else {
 		// got a raw ack
-		logger.Debug("Got raw ack", "fseq", fseq, "ack", ack, "rwin", rwin)
+		t.logger.Debug("Got raw ack", "fseq", fseq, "ack", ack, "rwin", rwin)
 	}
 }
 
-var udpPktCounter = 0
-
 // processUDPPacket processes a UDP packet from Linux -> MASQUE.
-func processUDPPacket(src uint32, sport uint16, dst uint32, dstIP net.IP, dport uint16, buf []byte) {
+func (t *PseudoTCP) processUDPPacket(src uint32, sport uint16, dst uint32, dstIP net.IP, dport uint16, buf []byte) {
 	// Special case for DNS.
 	if dport == 53 {
 		bufCopy := make([]byte, len(buf))
 		copy(bufCopy, buf)
-		go handleDNS(src, sport, dst, dport, bufCopy)
+		go t.handleDNS(src, sport, dst, dport, bufCopy)
 		return
 	}
 
-	flow, ok := activeUDPFlows[UDPFlowKey{src, sport, dst, dport}]
+	flow, ok := t.activeUDPFlows[UDPFlowKey{src, sport, dst, dport}]
 	if !ok {
 		flow = &UDPFlow{src: src, sport: sport, dst: dst, dport: dport}
-		if err := setupUDPMasque(dstIP, flow); err != nil {
+		if err := t.setupUDPMasque(dstIP, flow); err != nil {
 			// TODO: add more robust error handling, since it's possible we're offline.
 			// TODO: possibly attempt to reconnect to the proxy, and if that fails, make sure to signal that the VPN is down.
-			logger.Error("Error setting up masque for flow", "err", err, "flow", flow)
+			t.logger.Error("Error setting up masque for flow", "err", err, "flow", flow)
 			return
 		}
 
-		activeUDPFlows[UDPFlowKey{src, sport, dst, dport}] = flow
+		t.activeUDPFlows[UDPFlowKey{src, sport, dst, dport}] = flow
 	}
 
 	// Send the packet to MASQUE.
 	_, err := flow.proxyConn.Write(buf[DEFAULT_UDP_HDR_SIZE:])
 	if err != nil && err != io.ErrShortWrite {
-		logger.Error("Error writing received bytes to writer", "err", err, "flow", flow)
+		t.logger.Error("Error writing received bytes to writer", "err", err, "flow", flow)
 
 		// TODO: close/clean up any masque state held by this flow entry.
-		delete(activeUDPFlows, UDPFlowKey{src, sport, dst, dport})
+		delete(t.activeUDPFlows, UDPFlowKey{src, sport, dst, dport})
 		flow.garbageCollect = true
 		err := flow.proxyConn.Close()
 		if err != nil {
-			logger.Error("Error in flow.proxyConn.Close()", "err", err, "flow", flow)
+			t.logger.Error("Error in flow.proxyConn.Close()", "err", err, "flow", flow)
 		}
 
 		return
 	}
 
 	// Every 64K packets, clean up dead UDP flows in deadUDPFlows.
-	udpPktCounter += 1
-	if udpPktCounter&0xFFFF == 0 {
-		for _, flow := range deadUDPFlows {
+	t.udpPktCounter += 1
+	if t.udpPktCounter&0xFFFF == 0 {
+		for _, flow := range t.deadUDPFlows {
 			if flow.garbageCollect {
-				logger.Debug("Deleting dead UDP flow", "flow", flow)
-				delete(activeUDPFlows, UDPFlowKey{flow.src, flow.sport, flow.dst, flow.dport})
+				t.logger.Debug("Deleting dead UDP flow", "flow", flow)
+				delete(t.activeUDPFlows, UDPFlowKey{flow.src, flow.sport, flow.dst, flow.dport})
 			}
 		}
-		deadUDPFlows = deadUDPFlows[:0]
+		t.deadUDPFlows = t.deadUDPFlows[:0]
 	}
 }
 
 // UserStackIPProcessPacket processes an IPv4 packet and emits the generated reply to Linux and/or MASQUE.
-func UserStackIPProcessPacket(p []byte) {
-	if !relayActive {
+func (t *PseudoTCP) UserStackIPProcessPacket(p []byte) {
+	if !t.active {
 		return
 	}
 
 	// Before we do anything for this packet, check if there are any flows that have established in the meantime.
-	processPendingTCPSYNs()
+	t.processPendingTCPSYNs()
 
 	ver := p[IP_VERSION_IHL] >> 4
 	ihl := p[IP_VERSION_IHL] & 0x0F
@@ -1082,7 +811,7 @@ func UserStackIPProcessPacket(p []byte) {
 	}
 
 	if p[IP_DST] == WAKEUP_PACKET_IP_VALUE && p[IP_DST+1] == WAKEUP_PACKET_IP_VALUE && p[IP_DST+2] == WAKEUP_PACKET_IP_VALUE && p[IP_DST+3] == WAKEUP_PACKET_IP_VALUE {
-		logger.Debug("Got wakeup packet, ignore.")
+		t.logger.Debug("Got wakeup packet, ignore.")
 		return
 	}
 
@@ -1103,8 +832,8 @@ func UserStackIPProcessPacket(p []byte) {
 		(p[IP_DST] == 224 && p[IP_DST+1] == 0 && p[IP_DST+2] == 0) ||
 		(p[IP_DST] == 169 && p[IP_DST+1] == 254)
 
-	logger.Debug("IP matches disallowed check", "p", p)
-	if disallowedIP && ProhibitDisallowedIPPorts {
+	t.logger.Debug("IP matches disallowed check", "p", p)
+	if disallowedIP && t.prohibitDisallowedIPPorts {
 		icmpCode = 1 // host unreachable
 	}
 
@@ -1123,30 +852,30 @@ func UserStackIPProcessPacket(p []byte) {
 		copy(buf[DEFAULT_IP_HDR_SIZE+DEFAULT_ICMP_UNREACHABLE_HDR_SIZE:], p[:DEFAULT_IP_HDR_SIZE+DEFAULT_UDP_HDR_SIZE])
 		setIPandL4Checksum(buf[:], PROTO_ICMP)
 
-		if err := pseudoSendToLinux(buf[:]); err != nil {
-			logger.Error("Error in pseudoSendToLinux", "err", err)
+		if err := t.pseudoSendToLinux(buf[:]); err != nil {
+			t.logger.Error("Error in pseudoSendToLinux", "err", err)
 		}
 
 		return
 	}
 
 	if proto == PROTO_TCP {
-		processTCPPacket(src, sport, dst, p[IP_DST:IP_DST+4], dport, l4hdr)
+		t.processTCPPacket(src, sport, dst, p[IP_DST:IP_DST+4], dport, l4hdr)
 	} else if proto == PROTO_UDP {
-		processUDPPacket(src, sport, dst, p[IP_DST:IP_DST+4], dport, l4hdr)
+		t.processUDPPacket(src, sport, dst, p[IP_DST:IP_DST+4], dport, l4hdr)
 	}
 }
 
 // pseudoSendToLinux sends a packet to Android/Linux.
-func pseudoSendToLinux(p []byte) error {
-	if !relayActive {
+func (t *PseudoTCP) pseudoSendToLinux(p []byte) error {
+	if !t.active {
 		return errors.New("relay is not active")
 	}
 
-	err := toLinux(p, len(p))
+	err := t.toLinux(p, len(p))
 	if err != nil {
 		packet := gopacket.NewPacket(p[:], layers.LayerTypeIPv4, gopacket.Default)
-		logger.Error("Error sending packet to Linux", "err", err, "packet", packet)
+		t.logger.Error("Error sending packet to Linux", "err", err, "packet", packet)
 		return err
 	}
 

--- a/tests/integration/benchmark_test.go
+++ b/tests/integration/benchmark_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/invisv-privacy/pseudotcp"
 	"github.com/stretchr/testify/require"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
@@ -33,11 +32,7 @@ func BenchmarkThroughput(b *testing.B) {
 	}))
 	slog.SetDefault(logger)
 
-	// Set verbose to false
-	err := pseudotcp.Init(sendPacket, false, containerIP, "8444")
-	require.NoError(b, err, "pseudotcp.Init")
-
-	defer pseudotcp.Shutdown()
+	pTCP.SetLogger(logger)
 
 	// Start target HTTP/S server that replies with a payload determined by "?size" url query
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tests/integration/https_get_test.go
+++ b/tests/integration/https_get_test.go
@@ -19,17 +19,11 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
 	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
 
-	"github.com/invisv-privacy/pseudotcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHTTPSGet(t *testing.T) {
-	err := pseudotcp.Init(sendPacket, true, containerIP, "8444")
-	require.NoError(t, err, "pseudotcp.Init")
-
-	defer pseudotcp.Shutdown()
-
 	// Start target HTTP/S server
 	expectedResponse := "test http response data"
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tests/integration/udp_test.go
+++ b/tests/integration/udp_test.go
@@ -17,15 +17,10 @@ import (
 )
 
 func TestUDP(t *testing.T) {
-	err := pseudotcp.Init(sendPacket, true, containerIP, "8444")
-	require.NoError(t, err, "pseudotcp.Init")
-
-	defer pseudotcp.Shutdown()
-
 	sendBufferSize := pseudotcp.TUN_MTU - 150
 	receiveBufferSize := pseudotcp.INTERNET_MTU - 150
 	expectedRequest := make([]byte, sendBufferSize)
-	_, err = rand.Read(expectedRequest)
+	_, err := rand.Read(expectedRequest)
 	require.NoError(t, err, "rand.Read")
 	expectedReply := make([]byte, receiveBufferSize)
 	_, err = rand.Read(expectedReply)


### PR DESCRIPTION
This essentially takes all of the variables that were previously "package level" and moves them inside of a PseudoTCP struct. Correspondingly, it takes all of the "package level" functions and makes them methods of the PseudoTCP struct. 

This facilitates simpler creation, configuration, initialization as well as allows multiple instances of the PseudoTCP struct to be instantiated in parallel if necessary.

I'm opening this as a draft for now because I'd like feedback on this strategy, but I'd also like to refactor the `connectToProxy` method so that it could be a caller/instantiator provided config. That would do a number of things:
1. Allow the caller to provide their own options to the masque proxy
2. Allow the caller to choose between an http2 vs http3 masque proxy
3. Allow tests to mock that function which could allow for more granular unit-style testing